### PR TITLE
Changed from createObjectURL() to srcObject

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -82,9 +82,7 @@
 
         getUserMedia(videoSettings, function (stream) {
             //Setup the video stream
-            video.src = window.URL.createObjectURL(stream);
-
-            window.stream = stream;
+            video.srcObject=stream;
 
             video.addEventListener("loadedmetadata", function (e) {
                 //get video width and height as it might be different than we requested


### PR DESCRIPTION
Camera not working anymore because createObjectURL function is deprecated (in Chrome at least). Updated code to simply set srcObject to the MediaStream directly.